### PR TITLE
Update README.txt

### DIFF
--- a/README.txt
+++ b/README.txt
@@ -7,7 +7,8 @@ Tested up to: 4.1
 Stable tag: 1.3.5
 License: GPLv2 or later
 License URI: http://www.gnu.org/licenses/gpl-2.0.html
-
+WC requires at least: 2.2
+WC tested up to: 2.3
 Setup individual charges for each payment method in woocommerce.
 
 


### PR DESCRIPTION
Added
WC requires at least: 2.2
WC tested up to: 2.3

in the readme.txt as it is stated in http://docs.woothemes.com/document/create-a-plugin/
